### PR TITLE
Fix NameError: Forward reference bug in EditCommandResult

### DIFF
--- a/microedit/classes.py
+++ b/microedit/classes.py
@@ -7,7 +7,7 @@ class EditCommandResult:
     """Represents the result of an edit command."""
 
     def __init__(
-        self, quit_editor: bool = False, cursor_position: int = 0, file: File = None
+        self, quit_editor: bool = False, cursor_position: int = 0, file: "File" = None
     ):
         self.quit_editor = quit_editor
         self.cursor_position = cursor_position


### PR DESCRIPTION
Fixed the startup crash caused by a forward reference error in classes.py.

Changed line 10 from `file: File = None` to `file: "File" = None` to allow Python to properly handle the forward reference.

Tested on Windows 11, Python 3.12 - application now starts and works correctly.

Fixes #8