### PR TITLE
Fix: Edit command crash on blank file

### DIFF
--- a/microedit/classes.py
+++ b/microedit/classes.py
@@ -7,7 +7,7 @@ class EditCommandResult:
     """Represents the result of an edit command."""
 
     def __init__(
-        self, quit_editor: bool = False, cursor_position: int = 0, file: File = None
+        self, quit_editor: bool = False, cursor_position: int = 0, file: "File" = None
     ):
         self.quit_editor = quit_editor
         self.cursor_position = cursor_position

--- a/microedit/main.py
+++ b/microedit/main.py
@@ -46,7 +46,7 @@ def begin_editing(file_path):
 
 def edit(file: File):
     """Edit the file in a non-interactive way."""
-    cursor_position = len(file.content) - 1  # start at the end of the file
+    cursor_position = max(0, len(file.content) - 1)  # start at the end of the file, or 0 if empty
     # calculate context lines to show based on terminal size
     context_size = max(5, (os.get_terminal_size().lines - 3) // 2)
     while True:
@@ -137,12 +137,15 @@ def run_commands(
                 if len(parts) > 1:
                     new_content = " ".join(parts[1:])
                 else:
+                    # Check if file has content before accessing cursor position
+                    current_text = file.content[cursor_position].content if len(file.content) > 0 and cursor_position < len(file.content) else ""
                     new_content = input(
-                        f"E ({file.content[cursor_position].content}) / "
+                        f"E ({current_text}) / "
                     )
-
+                
                 if len(file.content) == 0:
                     file.content.append(Line(new_content))
+                    cursor_position = 0  # Set cursor to first line
                 else:
                     file.content[cursor_position].content = new_content
             case "r" | "remove":


### PR DESCRIPTION
Fixed IndexError when running `e` command on empty files.

**Changes:**
- Added validation for empty file.content before accessing cursor position
- Fixed cursor initialization to handle empty files
- Set cursor to 0 when creating first line in empty file

Fixes #7