### PR TITLE
Tiny JSON-based config system for Medit

### DIFF
--- a/microedit/config.py
+++ b/microedit/config.py
@@ -1,0 +1,344 @@
+"""Configuration loading for medit.
+
+Config is JSON only, to keep things dependency-free on Python 3.10+.
+
+When no config file is found, medit will try to create a default config in the
+user config directory. If that fails, medit falls back to defaults and continues.
+"""
+
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass, field, fields, is_dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from .config_validators import FieldValidator, validate_string
+
+
+class ConfigError(Exception):
+    """Raised when a config file exists but cannot be parsed/validated."""
+
+    def __init__(self, message: str, *, path: Path | None = None):
+        super().__init__(message)
+        self.path = path
+
+
+@dataclass(frozen=True)
+class CommandsConfig:
+    separator: str = field(
+        default=",",
+        metadata={
+            "validator": validate_string(
+                label="Command separator", allow_empty=False, forbid_newlines=True
+            )
+        },
+    )
+
+
+@dataclass(frozen=True)
+class MeditConfig:
+    commands: CommandsConfig = field(default_factory=CommandsConfig)
+
+
+@dataclass(frozen=True)
+class ConfigDiagnostics:
+    path: Path | None = None
+    warnings: tuple[str, ...] = ()
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class ConfigResult:
+    config: MeditConfig
+    diagnostics: ConfigDiagnostics
+
+
+_CACHED_RESULT: ConfigResult | None = None
+
+
+def _user_config_dir(app_name: str) -> Path:
+    match sys.platform:
+        case "win32":
+            base = os.getenv("APPDATA") or os.getenv("LOCALAPPDATA")
+            if base:
+                return Path(base) / app_name
+            return Path.home() / "AppData" / "Roaming" / app_name
+        case "darwin":
+            return Path.home() / "Library" / "Application Support" / app_name
+        case _:
+            base = os.getenv("XDG_CONFIG_HOME")
+            if base:
+                return Path(base) / app_name
+            return Path.home() / ".config" / app_name
+
+
+def _expand_path(raw: str) -> Path:
+    expanded = os.path.expandvars(os.path.expanduser(raw))
+    return Path(expanded)
+
+
+def _env_config_path() -> Path | None:
+    raw = os.getenv("MEDIT_CONFIG") or os.getenv("MICROEDIT_CONFIG")
+    if not raw:
+        return None
+    return _expand_path(raw)
+
+
+def config_search_paths() -> list[Path]:
+    """Return config paths in the order they should be considered."""
+
+    paths: list[Path] = []
+
+    # Local (project) config.
+    cwd = Path.cwd()
+    paths.extend(
+        [
+            cwd / "medit.json",
+            cwd / ".medit.json",
+        ]
+    )
+
+    # User config.
+    user_dir = _user_config_dir("medit")
+    paths.append(user_dir / "config.json")
+
+    return paths
+
+
+def default_config_path() -> Path:
+    return _user_config_dir("medit") / "config.json"
+
+
+def default_config_data() -> dict[str, Any]:
+    return asdict(MeditConfig())
+
+
+def default_config_text() -> str:
+    return json.dumps(default_config_data(), indent=2, sort_keys=True) + "\n"
+
+
+def write_default_config(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(default_config_text(), encoding="utf-8")
+
+
+def discover_config_path() -> Path | None:
+    env_path = _env_config_path()
+    if env_path is not None:
+        return env_path
+
+    for path in config_search_paths():
+        if path.is_file():
+            return path
+
+    return None
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ConfigError("JSON config root must be an object.", path=path)
+    return data
+
+
+def _load_raw_config(path: Path) -> dict[str, Any]:
+    suffix = path.suffix.lower()
+    if suffix != ".json":
+        raise ConfigError(
+            f"Unsupported config file type '{path.suffix}'. Use .json.", path=path
+        )
+    return _load_json(path)
+
+
+def _validate_like_default(
+    value: Any, default: Any, *, path: Path | None, field_name: str
+) -> Any:
+    if value is None:
+        return default
+
+    match default:
+        case bool():
+            if isinstance(value, bool):
+                return value
+            raise ConfigError(f"{field_name} must be a boolean.", path=path)
+        case int():
+            if isinstance(value, int) and not isinstance(value, bool):
+                return value
+            raise ConfigError(f"{field_name} must be an integer.", path=path)
+        case float():
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return float(value)
+            raise ConfigError(f"{field_name} must be a number.", path=path)
+        case str():
+            if isinstance(value, str):
+                return value
+            raise ConfigError(f"{field_name} must be a string.", path=path)
+        case list():
+            if isinstance(value, list):
+                return value
+            raise ConfigError(f"{field_name} must be a list.", path=path)
+        case tuple():
+            if isinstance(value, list):
+                return tuple(value)
+            if isinstance(value, tuple):
+                return value
+            raise ConfigError(f"{field_name} must be a list.", path=path)
+        case dict():
+            if isinstance(value, Mapping):
+                return dict(value)
+            raise ConfigError(f"{field_name} must be an object.", path=path)
+        case _:
+            return value
+
+
+def validate_config(data: Mapping[str, Any], *, path: Path | None = None) -> ConfigResult:
+    """Validate raw config data and build a typed config object."""
+
+    warnings: list[str] = []
+
+    if not isinstance(data, Mapping):
+        raise ConfigError("Config root must be a table/object.", path=path)
+
+    default_config = MeditConfig()
+    allowed_root_keys = {f.name for f in fields(MeditConfig)}
+    unknown_root_keys = sorted(set(data.keys()) - allowed_root_keys)
+    if unknown_root_keys:
+        warnings.append(f"Unknown top-level keys: {', '.join(unknown_root_keys)}")
+
+    built_sections: dict[str, Any] = {}
+    for section_field in fields(MeditConfig):
+        section_name = section_field.name
+        default_section = getattr(default_config, section_name)
+        if not is_dataclass(default_section):
+            raise ConfigError(
+                f"Internal error: config field '{section_name}' must be a dataclass.",
+                path=path,
+            )
+
+        section_data = data.get(section_name, {})
+        if section_data is None:
+            section_data = {}
+        if not isinstance(section_data, Mapping):
+            raise ConfigError(
+                f"[{section_name}] must be a table/object.",
+                path=path,
+            )
+
+        allowed_section_keys = {f.name for f in fields(type(default_section))}
+        unknown_section_keys = sorted(set(section_data.keys()) - allowed_section_keys)
+        if unknown_section_keys:
+            warnings.append(
+                f"Unknown [{section_name}] keys: {', '.join(unknown_section_keys)}"
+            )
+
+        section_kwargs: dict[str, Any] = {}
+        for option_field in fields(type(default_section)):
+            option_name = option_field.name
+            field_name = f"{section_name}.{option_name}"
+            default_value = getattr(default_section, option_name)
+            raw_value = section_data.get(option_name, default_value)
+
+            field_validators: tuple[FieldValidator, ...] = ()
+            validators = option_field.metadata.get("validators")
+            if validators is not None:
+                field_validators = tuple(validators)
+            else:
+                validator = option_field.metadata.get("validator")
+                if validator is not None:
+                    field_validators = (validator,)
+
+            if field_validators:
+                value: Any = raw_value
+                for validator in field_validators:
+                    try:
+                        value = validator(
+                            value,
+                            default_value,
+                            path=path,
+                            field_name=field_name,
+                        )
+                    except ConfigError:
+                        raise
+                    except ValueError as exc:
+                        raise ConfigError(str(exc), path=path) from exc
+                section_kwargs[option_name] = value
+            else:
+                section_kwargs[option_name] = _validate_like_default(
+                    raw_value,
+                    default_value,
+                    path=path,
+                    field_name=field_name,
+                )
+
+        built_sections[section_name] = type(default_section)(**section_kwargs)
+
+    config = MeditConfig(**built_sections)
+    return ConfigResult(
+        config=config,
+        diagnostics=ConfigDiagnostics(path=path, warnings=tuple(warnings)),
+    )
+
+
+def load_config(path: Path) -> ConfigResult:
+    raw = _load_raw_config(path)
+    return validate_config(raw, path=path)
+
+
+def get_config_result() -> ConfigResult:
+    """Load and cache the resolved config + diagnostics."""
+
+    global _CACHED_RESULT
+    if _CACHED_RESULT is not None:
+        return _CACHED_RESULT
+
+    env_path = _env_config_path()
+    if env_path is not None and not env_path.is_file():
+        _CACHED_RESULT = ConfigResult(
+            config=MeditConfig(),
+            diagnostics=ConfigDiagnostics(
+                path=env_path,
+                error=f"Config file from $MEDIT_CONFIG not found: {env_path}",
+            ),
+        )
+        return _CACHED_RESULT
+
+    config_path = discover_config_path()
+    if config_path is None:
+        # No config exists yet: try to create a default one in the user config dir.
+        default_path = default_config_path()
+        try:
+            write_default_config(default_path)
+            config_path = default_path
+        except OSError as exc:
+            _CACHED_RESULT = ConfigResult(
+                config=MeditConfig(),
+                diagnostics=ConfigDiagnostics(
+                    path=default_path,
+                    error=f"Failed to create default config: {exc}",
+                ),
+            )
+            return _CACHED_RESULT
+
+    try:
+        _CACHED_RESULT = load_config(config_path)
+        return _CACHED_RESULT
+    except ConfigError as exc:
+        _CACHED_RESULT = ConfigResult(
+            config=MeditConfig(),
+            diagnostics=ConfigDiagnostics(
+                path=exc.path or config_path,
+                error=str(exc),
+            ),
+        )
+        return _CACHED_RESULT
+
+
+def get_config() -> MeditConfig:
+    return get_config_result().config
+
+
+def clear_config_cache() -> None:
+    global _CACHED_RESULT
+    _CACHED_RESULT = None

--- a/microedit/config_validators.py
+++ b/microedit/config_validators.py
@@ -1,0 +1,216 @@
+"""Reusable validators for Medit config fields.
+
+These validators are intended to be attached to dataclass fields via metadata:
+
+    from dataclasses import field
+    from .config_validators import validate_string
+
+    name: str = field(default="x", metadata={"validator": validate_string(...)})
+
+Validators should raise ValueError with a human-friendly message. The config loader
+wraps that into a ConfigError that includes the config file path.
+"""
+
+from pathlib import Path
+from typing import Any, Mapping, Protocol
+
+
+class FieldValidator(Protocol):
+    def __call__(
+        self,
+        value: Any,
+        default: Any,
+        *,
+        path: Path | None,
+        field_name: str,
+    ) -> Any: ...
+
+
+def validate_bool(*, label: str | None = None) -> FieldValidator:
+    def _validator(
+        value: Any,
+        default: Any,
+        *,
+        path: Path | None,
+        field_name: str,
+    ) -> bool:
+        if value is None:
+            value = default
+
+        display = label or field_name
+        if not isinstance(value, bool):
+            raise ValueError(f"{display} must be a boolean.")
+        return value
+
+    return _validator
+
+
+def validate_int(
+    *,
+    label: str | None = None,
+    min_value: int | None = None,
+    max_value: int | None = None,
+) -> FieldValidator:
+    def _validator(
+        value: Any,
+        default: Any,
+        *,
+        path: Path | None,
+        field_name: str,
+    ) -> int:
+        if value is None:
+            value = default
+
+        display = label or field_name
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError(f"{display} must be an integer.")
+        if min_value is not None and value < min_value:
+            raise ValueError(f"{display} must be >= {min_value}.")
+        if max_value is not None and value > max_value:
+            raise ValueError(f"{display} must be <= {max_value}.")
+        return value
+
+    return _validator
+
+
+def validate_number(
+    *,
+    label: str | None = None,
+    min_value: float | None = None,
+    max_value: float | None = None,
+) -> FieldValidator:
+    def _validator(
+        value: Any,
+        default: Any,
+        *,
+        path: Path | None,
+        field_name: str,
+    ) -> float:
+        if value is None:
+            value = default
+
+        display = label or field_name
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise ValueError(f"{display} must be a number.")
+
+        value_f = float(value)
+        if min_value is not None and value_f < min_value:
+            raise ValueError(f"{display} must be >= {min_value}.")
+        if max_value is not None and value_f > max_value:
+            raise ValueError(f"{display} must be <= {max_value}.")
+        return value_f
+
+    return _validator
+
+
+def validate_string(
+    *,
+    label: str | None = None,
+    allow_empty: bool = True,
+    forbid_newlines: bool = False,
+    strip: bool = False,
+    min_length: int | None = None,
+    max_length: int | None = None,
+) -> FieldValidator:
+    def _validator(
+        value: Any,
+        default: Any,
+        *,
+        path: Path | None,
+        field_name: str,
+    ) -> str:
+        if value is None:
+            value = default
+
+        display = label or field_name
+
+        if not isinstance(value, str):
+            raise ValueError(f"{display} must be a string.")
+
+        if strip:
+            value = value.strip()
+
+        if not allow_empty and value == "":
+            raise ValueError(f"{display} must not be empty.")
+        if min_length is not None and len(value) < min_length:
+            raise ValueError(f"{display} must be at least {min_length} characters.")
+        if max_length is not None and len(value) > max_length:
+            raise ValueError(f"{display} must be at most {max_length} characters.")
+        if forbid_newlines and ("\n" in value or "\r" in value):
+            raise ValueError(f"{display} must not contain newlines.")
+
+        return value
+
+    return _validator
+
+
+def validate_one_of(*choices: Any, label: str | None = None) -> FieldValidator:
+    if not choices:
+        raise ValueError("validate_one_of requires at least one choice.")
+
+    def _validator(
+        value: Any,
+        default: Any,
+        *,
+        path: Path | None,
+        field_name: str,
+    ) -> Any:
+        if value is None:
+            value = default
+
+        display = label or field_name
+        if value not in choices:
+            formatted = ", ".join(repr(c) for c in choices)
+            raise ValueError(f"{display} must be one of: {formatted}.")
+
+        return value
+
+    return _validator
+
+
+def validate_list(
+    *,
+    label: str | None = None,
+    min_length: int | None = None,
+    max_length: int | None = None,
+) -> FieldValidator:
+    def _validator(
+        value: Any,
+        default: Any,
+        *,
+        path: Path | None,
+        field_name: str,
+    ) -> list[Any]:
+        if value is None:
+            value = default
+
+        display = label or field_name
+        if not isinstance(value, list):
+            raise ValueError(f"{display} must be a list.")
+        if min_length is not None and len(value) < min_length:
+            raise ValueError(f"{display} must have at least {min_length} items.")
+        if max_length is not None and len(value) > max_length:
+            raise ValueError(f"{display} must have at most {max_length} items.")
+        return value
+
+    return _validator
+
+
+def validate_object(*, label: str | None = None) -> FieldValidator:
+    def _validator(
+        value: Any,
+        default: Any,
+        *,
+        path: Path | None,
+        field_name: str,
+    ) -> dict[str, Any]:
+        if value is None:
+            value = default
+
+        display = label or field_name
+        if not isinstance(value, Mapping):
+            raise ValueError(f"{display} must be an object.")
+        return dict(value)
+
+    return _validator
+

--- a/microedit/constants.py
+++ b/microedit/constants.py
@@ -5,9 +5,12 @@ import os
 from objlog.LogMessages import Fatal, Info
 from objlog import LogNode
 
+from .config import get_config_result
+
 VERSION = "1.1.1"
 
-COMMAND_SEPARATOR_CHAR = ","
+CONFIG_RESULT = get_config_result()
+COMMAND_SEPARATOR_CHAR = CONFIG_RESULT.config.commands.separator
 
 LOG_DIR: str
 

--- a/microedit/main.py
+++ b/microedit/main.py
@@ -6,7 +6,7 @@ import os
 from objlog.LogMessages import Debug, Info, Warn, Error
 
 from .classes import Line, File, EditCommandResult
-from .constants import LOG_DIR, LOG, VERSION, COMMAND_SEPARATOR_CHAR
+from .constants import LOG_DIR, LOG, VERSION, COMMAND_SEPARATOR_CHAR, CONFIG_RESULT
 
 from .commands import execute_command
 
@@ -145,6 +145,16 @@ def main():
     args = parser.parse_args()
 
     LOG.log(Debug(f"Arguments: {args}"))
+
+    if CONFIG_RESULT.diagnostics.error:
+        LOG.log(
+            Warn(
+                f"Config error ({CONFIG_RESULT.diagnostics.path}): "
+                f"{CONFIG_RESULT.diagnostics.error}. Using defaults."
+            )
+        )
+    for warning in CONFIG_RESULT.diagnostics.warnings:
+        LOG.log(Warn(f"Config warning ({CONFIG_RESULT.diagnostics.path}): {warning}"))
 
     if args.command:
         command_str = " ".join(args.command).strip()


### PR DESCRIPTION
My apologies for taking this long; had to finish some stuff of my own first. But at least it's ready now!! Happy (late) New Year 2026!

I'll try to keep things fairly structured here if that's okay, so that you don't have to read my essays. 😉

>[!NOTE]
> No docs yet, I'm not sure where you'll want to put them, but we'll **definitely** need some documentation for this thing.

## PR: Universal JSON config file

So, at first, I suggested adding a TOML-based config system, it seemed like a great idea at first since Python supports TOML natively... But only since 3.11. Medit has support for 3.10 and higher, meaning that there we'd have to install the external `tomli` dependency. It's not that bad, but generally, I wanted to avoid dependencies so that we don't make this a heavyweight addition.

So I went with JSON instead! It's fairly cross-platform, readable, and easy to work with.

## The concept

The config file is fully _**optional**_ and (explained above) _**dependency-free**_. If it's missing or invalid, we'll just log warnings and go with defaults. As you mentioned in your issue #1, the Separator option needs to be configurable, so that's the one I added for now (and you can use it as an example for any additional options when/if `medit` grows bigger).

So the goals here were:

- keep it minimal and easy to maintain (stdlib only)
- make it easy to extend (add a field / add a section)
- fail safely (never crash on bad config; fall back to defaults)

## User-facing behavior

We scan .env variables in case the user wants to move the dir somewhere else, specifically `$MEDIT_CONFIG` (or `$MICROEDIT_CONFIG`). Either of them is treated as a file path; they're checked first (high priority). Then goes the `./medit.json` or `./.medit.json` (in cwd). And lastly, we check the user config folders:

   - Linux: `~/.config/medit/config.json` (or `$XDG_CONFIG_HOME/medit/config.json`)
   - macOS: `~/Library/Application Support/medit/config.json`
   - Windows: `%APPDATA%\\medit\\config.json`

If no config exists, Medit attempts to create the default user config file with the current defaults.

Example `config.json`:
```json
{
  "commands": {
    "separator": ";"
  }
}
```

## Implementation notes

Best to see the code, but for a quick skim, here's what I did:

- `microedit/config.py` ➕
  - Defines the typed "schema" via dataclasses (`MeditConfig`, `CommandsConfig`)
  - Implements discovery, loading, default writing, validation, and diagnostics
  - Produces a `ConfigResult` containing both:
    - `config` (typed config object)
    - `diagnostics` (path, warnings, error string)
    
- `microedit/config_validators.py` ➕
  - Reusable, opt-in field validators (attached via dataclass field metadata)
  
- `microedit/constants.py` ✏️
  - Loads config once and exposes:
    - `CONFIG_RESULT` (config + diagnostics)
    - config-driven constants like `COMMAND_SEPARATOR_CHAR`

- `microedit/main.py` ✏️
  - Logs config warnings/errors at startup

Anddddd for completeness, there's validation. At first, I thought I'd add validators for each setting, but that's a very, VERY fast way to make DRY weep, so instead I used something like a "list of toggles" validator structure. With it:

- Known fields are validated (“same type as default”), with optional field-level validators for extra constraints (those are the toggles I mentioned).
- Unknown keys are tolerated and reported as warnings (so config files remain forward-compatible).

## Note about caching

So that we don't load the config on every single thing that's done, I loaded it into a cache for the process's lifetime. I don't think we're going to need to re-read it all the time. If needed, there's a utility function to clear the current "cache".

# How to extend (high level)

To add a new option:
1. Add a field to an existing section dataclass (or create a new section dataclass).
2. Add it to `MeditConfig` if it’s a new section.
3. If the option needs constraints beyond type checking, attach a validator to the field (see `microedit/config_validators.py`).
4. Use the typed value from config (or expose it as a constant if used widely).

---

So that's pretty much it! Let me know if you also want me to write the docs. The system here took quite a bit of effort to polish out, but it was a fun challenge in any case. 

Cheers! ✨

*P.S. Your repo doesn't have any automated tests or requirements for them in the contributing guidelines. To verify everything works, I created a tiny smoke-test script for myself. It's not committed here, but I can include it if you want. Not a full pytest suite, but it just works.